### PR TITLE
feat/home page api

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CheckStyle-IDEA" serialisationVersion="2">
+    <checkstyleVersion>10.13.0</checkstyleVersion>
+    <scanScope>JavaOnly</scanScope>
+    <copyLibs>true</copyLibs>
+    <option name="thirdPartyClasspath" />
+    <option name="activeLocationIds" />
+    <option name="locations">
+      <list>
+        <ConfigurationLocation id="bundled-sun-checks" type="BUNDLED" scope="All" description="Sun Checks">(bundled)</ConfigurationLocation>
+        <ConfigurationLocation id="bundled-google-checks" type="BUNDLED" scope="All" description="Google Checks">(bundled)</ConfigurationLocation>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.30/f195ee86e6c896ea47a1d39defbe20eb59cd149d/lombok-1.18.30.jar" />
+        </processorPath>
+        <module name="webserver.main" />
+      </profile>
+    </annotationProcessing>
+    <bytecodeTargetLevel>
+      <module name="webserver" target="17" />
+    </bytecodeTargetLevel>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/webserver" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/webserver" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$/webserver" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/webserver/src/main/java/com/example/web/server/common/repository/CommonResponse.java
+++ b/webserver/src/main/java/com/example/web/server/common/repository/CommonResponse.java
@@ -1,0 +1,24 @@
+package com.example.web.server.common.repository;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class CommonResponse<T> {
+	private boolean success;
+	private int code;
+	private String message;
+	private T data;
+
+	public static<T> CommonResponse<T> res(final boolean success,final int code, final String message,final T t){
+		return CommonResponse.<T>builder()
+			.data(t)
+			.message(message)
+			.code(code)
+			.success(success)
+			.build();
+	}
+}

--- a/webserver/src/main/java/com/example/web/server/common/repository/StatusCode.java
+++ b/webserver/src/main/java/com/example/web/server/common/repository/StatusCode.java
@@ -1,0 +1,15 @@
+package com.example.web.server.common.repository;
+
+public class StatusCode {
+	public static final int OK = 200;
+	public static final int CREATED = 201;
+	public static final int NO_CONTENT = 204;
+	public static final int BAD_REQUEST =  400;
+	public static final int UNAUTHORIZED = 401;
+	public static final int FORBIDDEN = 403;
+	public static final int NOT_FOUND = 404;
+	public static final int CONFLICT = 409;
+	public static final int INTERNAL_SERVER_ERROR = 500;
+	public static final int SERVICE_UNAVAILABLE = 503;
+	public static final int DB_ERROR = 600;
+}

--- a/webserver/src/main/java/com/example/web/server/home/controller/HomeController.java
+++ b/webserver/src/main/java/com/example/web/server/home/controller/HomeController.java
@@ -1,0 +1,44 @@
+package com.example.web.server.home.controller;
+
+import java.time.LocalDate;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import com.example.web.server.common.repository.CommonResponse;
+import com.example.web.server.common.repository.StatusCode;
+import com.example.web.server.home.service.HomeService;
+
+import lombok.AllArgsConstructor;
+
+@Controller
+@RequestMapping("/home")
+@AllArgsConstructor // @RequiredArgsConstructor와 비교해서 신중히 고르기
+public class HomeController {
+	private final HomeService popUpStoreInfoService;
+
+	@GetMapping("/get/imagelist")
+	public ResponseEntity imagesList(){
+		String message = "홈화면에 이미지리스트 조회를 성공했습니다.";
+		LocalDate today = LocalDate.now();
+		return new ResponseEntity(CommonResponse.res(true, StatusCode.OK, message,popUpStoreInfoService.ImageList(today)),null, HttpStatus.OK);
+	}
+
+	@GetMapping("/get/popup")
+	public ResponseEntity imagesList(@RequestParam LocalDate date){
+		String message = "날짜별 팝업 카드 결과 조회를 성공했습니다.";
+		// 1. 랜덤 구현 추가 필요
+		return new ResponseEntity(CommonResponse.res(true, StatusCode.OK, message,popUpStoreInfoService.ImageList(date)),null, HttpStatus.OK);
+	}
+
+	@GetMapping("/get/popup/search")
+	public ResponseEntity searchList(@RequestParam String query, @RequestParam String area, @RequestParam String date){
+		String message = "홈화면에 상단 검색 결과 조회를 성공했습니다.";
+		// 수정 필요 (팀원들에게 묻기)
+		return new ResponseEntity(CommonResponse.res(true, StatusCode.OK, message,popUpStoreInfoService.SearchList(query,area,date)),null, HttpStatus.OK);
+	}
+}

--- a/webserver/src/main/java/com/example/web/server/home/dto/ImageListResponse.java
+++ b/webserver/src/main/java/com/example/web/server/home/dto/ImageListResponse.java
@@ -1,0 +1,23 @@
+package com.example.web.server.home.dto;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+@Builder
+public class ImageListResponse {
+	private String id;
+	private String url;
+	private String name;
+	private LocalDate startDate;
+	private LocalDate endDate;
+	private String address;
+}

--- a/webserver/src/main/java/com/example/web/server/home/repository/HomeRepository.java
+++ b/webserver/src/main/java/com/example/web/server/home/repository/HomeRepository.java
@@ -1,5 +1,9 @@
 package com.example.web.server.home.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.data.domain.PopUpStoreInfo;
@@ -7,4 +11,43 @@ import com.example.web.server.common.repository.GenericRepository;
 
 @Repository
 public interface HomeRepository extends GenericRepository<PopUpStoreInfo, String> {
+	@Query("{ 'startDate': { '$lte': ?0 }, 'endDate': { '$gte': ?0 } }")
+	List<PopUpStoreInfo> findByDateInRange(LocalDate date);
+
+	@Query("{$or: [" +
+		"{'name': {$regex: ?1, $options: 'i'}}, " + // Case-insensitive match of 'query' within 'name'
+		"{'region': {$eq: ?2}}, " +
+		"{'startDate': {$lte: ?0}}, " +
+		"{'endDate': {$gte: ?0}}]}")
+	List<PopUpStoreInfo> findByDateNameAndRegion(LocalDate date, String query, String area);
+
+	@Query("{$or: [" +
+		"{'region': {$eq: ?1}}, " +
+		"{'startDate': {$lte: ?0}}, " +
+		"{'endDate': {$gte: ?0}}]}")
+	List<PopUpStoreInfo> findByDateAndRegion(LocalDate date,  String area);
+
+	@Query("{$or: [" +
+		"{'name': {$regex: ?1, $options: 'i'}}, " + // Case-insensitive match of 'query' within 'name'
+		"{'startDate': {$lte: ?0}}, " +
+		"{'endDate': {$gte: ?0}}]}")
+	List<PopUpStoreInfo> findByDateName(LocalDate date, String query);
+
+	@Query("{$or: [" +
+		"{'name': {$regex: ?0, $options: 'i'}}, " + // Case-insensitive match of 'query' within 'name'
+		"{'region': {$eq: ?1}}]}" )
+	List<PopUpStoreInfo> findByNameAndRegion(String query, String area);
+
+	@Query("{$or: [" +
+		"{'startDate': {$lte: ?0}}, " +
+		"{'endDate': {$gte: ?0}}]}")
+	List<PopUpStoreInfo> findByDate(LocalDate date);
+
+	@Query("{$or: [" +
+		"{'region': {$eq: ?0}}]}")
+	List<PopUpStoreInfo> findByRegion(String area);
+
+	@Query("{$or: [" +
+		"{'name': {$regex: ?0, $options: 'i'}}]}") // Case-insensitive match of 'query' within 'name'
+	List<PopUpStoreInfo> findByName(String query);
 }

--- a/webserver/src/main/java/com/example/web/server/home/service/HomeService.java
+++ b/webserver/src/main/java/com/example/web/server/home/service/HomeService.java
@@ -1,0 +1,92 @@
+package com.example.web.server.home.service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.data.domain.PopUpStoreInfo;
+import com.example.web.server.home.dto.ImageListResponse;
+import com.example.web.server.home.repository.HomeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+	private final HomeRepository infoRepository;
+
+	@Transactional
+	public List<ImageListResponse> ImageList(LocalDate date){
+		List<ImageListResponse> response = new ArrayList<>();
+
+		//LocalDate now = LocalDate.parse("2024-04-19");
+		List<PopUpStoreInfo> info = infoRepository.findByDateInRange(date);
+
+		if (!info.isEmpty()) {
+			for (int i = 0 ; i < 8 ; i ++){
+				ImageListResponse imageListResponse = new ImageListResponse();
+				imageListResponse.setId(info.get(i).getId());
+				if(imageListResponse.getUrl() != null){
+					imageListResponse.setUrl(info.get(i).getUrls().get(0));
+				}
+				imageListResponse.setName(info.get(i).getName());
+				imageListResponse.setStartDate(info.get(i).getStartDate());
+				imageListResponse.setEndDate(info.get(i).getEndDate());
+				imageListResponse.setAddress(info.get(i).getAddress());
+
+				response.add(i,imageListResponse);
+			}
+		}
+
+		return response;
+	}
+	@Transactional
+	public List<ImageListResponse> SearchList(String query, String area, String date) {
+		List<ImageListResponse> response = new ArrayList<>();
+		List<PopUpStoreInfo> info = new ArrayList<>();
+		if (!query.isEmpty() && !area.isEmpty() && !date.isEmpty()) {
+			info = infoRepository.findByDateNameAndRegion(LocalDate.parse(date), query, area);
+		}
+		else if(query.isEmpty() && !area.isEmpty() && !date.isEmpty()){
+			info = infoRepository.findByDateAndRegion(LocalDate.parse(date), area);
+		}
+		else if(!query.isEmpty() &&  area.isEmpty() && !date.isEmpty()){
+			info = infoRepository.findByDateName(LocalDate.parse(date), query);
+		}
+		else if(!query.isEmpty() &&  !area.isEmpty() && date.isEmpty()){
+			info = infoRepository.findByNameAndRegion(query, area);
+		}
+		else if(query.isEmpty() && area.isEmpty() && !date.isEmpty()){
+			info = infoRepository.findByDate(LocalDate.parse(date));
+		}
+		else if(query.isEmpty() && !area.isEmpty() && date.isEmpty()){
+			info = infoRepository.findByRegion(area);
+		}
+		else if(!query.isEmpty() && area.isEmpty() && date.isEmpty()){
+			info = infoRepository.findByName(query);
+		}
+
+
+
+		if (!info.isEmpty()) {
+			for (int i = 0 ; i < info.size() ; i ++){
+				ImageListResponse imageListResponse = new ImageListResponse();
+				imageListResponse.setId(info.get(i).getId());
+				if(imageListResponse.getUrl() != null){
+					imageListResponse.setUrl(info.get(i).getUrls().get(0));
+				}
+				imageListResponse.setName(info.get(i).getName());
+				imageListResponse.setStartDate(info.get(i).getStartDate());
+				imageListResponse.setEndDate(info.get(i).getEndDate());
+				imageListResponse.setAddress(info.get(i).getAddress());
+
+				response.add(i,imageListResponse);
+			}
+		}
+
+		return response;
+	}
+}


### PR DESCRIPTION
+ 패키지 구조

```
 com.example.web.server
 └── common.repository
    ├── CommonResponse.java
    └── StatusCode.java
```


```
 home
 ├── controller
 │   └──HomeController.java
 ├── dto
 │   └── ImageListResponse.java
 ├── repository
 │   └── HomeRepository.java
 └── service
     └── HomeService.java
```
+ common.repository
 `CommonResponse.java` : 
 `StatusCode.java`: 



+ controller
 `/HomeController.java` : 비즈니스 로직의 메서드들과 엔드포인트를 연결하는 역할을 함, 3개의 API
+ dto
 `/ImageListResponse.java` : **리턴** 받을 데이터의 정보 규격
+ repository
 `/HomeRepository.java` : 스프링 부트와 mongoDB 간 **통신을 위한 객체**
+ service
 `/HomeService.java` : 날짜, 팝업 제목, 지역의 정보를 입력받아 일치하는 **텍스트 정보(DetailInfo)를 리턴**함
